### PR TITLE
UIOR-325 fix selecting a Line via checkbox

### DIFF
--- a/FindPOLine/FindPOLineModal/FindPOLineModal.js
+++ b/FindPOLine/FindPOLineModal/FindPOLineModal.js
@@ -77,21 +77,34 @@ class FindPOLineModal extends React.Component {
     this.props.onCloseModal();
   }
 
+  clickCheckbox = (e) => e.stopPropagation();
+
+  toggleLine = (e, line) => {
+    const { id } = line;
+
+    this.setState((state) => {
+      const checkedLinesMap = { ...state.checkedLinesMap };
+
+      if (checkedLinesMap[id]) {
+        delete checkedLinesMap[id];
+      } else {
+        checkedLinesMap[id] = line;
+      }
+
+      return {
+        checkedLinesMap,
+        isAllChecked: false,
+      };
+    });
+  }
+
   onSelectRow = (e, line) => {
     if (this.props.isSingleSelect) {
       this.props.addLines([line]);
       this.closeModal();
-    } else {
-      const { id } = line;
-
-      this.setState(({ checkedLinesMap }) => ({
-        checkedLinesMap: {
-          ...checkedLinesMap,
-          [id]: checkedLinesMap[id] ? null : line,
-        },
-        isAllChecked: false,
-      }));
     }
+
+    return false;
   }
 
   save = () => {
@@ -143,6 +156,8 @@ class FindPOLineModal extends React.Component {
             data-test-find-po-line-modal-select-all
             type="checkbox"
             checked={Boolean(checkedLinesMap[data.id])}
+            onClick={this.clickCheckbox}
+            onChange={(e) => this.toggleLine(e, data)}
           />
         ),
       };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "node": ">=8.9.4"
   },
   "stripes": {
-    "type": "plugin",
+    "actsAs": ["plugin"],
     "pluginType": "find-po-line",
     "displayName": "ui-plugin-find-po-line.meta.title",
     "okapiInterfaces": {

--- a/test/bigtest/interactors/findPOLines.js
+++ b/test/bigtest/interactors/findPOLines.js
@@ -12,6 +12,7 @@ import {
 
   instances = collection('[role=row] a', {
     click: clickable(),
+    selectLine: clickable('input[type="checkbox"]'),
   });
 
   save = scoped('[data-test-find-po-line-modal-save]', {

--- a/test/bigtest/tests/findPOLines.e2e.js
+++ b/test/bigtest/tests/findPOLines.e2e.js
@@ -48,7 +48,7 @@ describe('Find PO Lines plugin', function () {
 
     describe('select a line', function () {
       beforeEach(async function () {
-        await findPOLines.modal.instances(1).click();
+        await findPOLines.modal.instances(1).selectLine();
       });
 
       it('should enable Save button', function () {


### PR DESCRIPTION
*Findings*:
The key change is to use `onClick` handler in addition to `onChange` on the `Checkbox` component. It's required to stop event of clicking row at the time user wants to click just the checkbox.