### PR TITLE
Remove tabIndex

### DIFF
--- a/FindPOLine/FindPOLine.js
+++ b/FindPOLine/FindPOLine.js
@@ -56,7 +56,6 @@ class FindPOLine extends React.Component {
           key="searchButton"
           marginBottom0={marginBottom0}
           onClick={this.openModal}
-          tabIndex="-1"
         >
           {searchLabel}
         </Button>


### PR DESCRIPTION
Setting `tabIndex="-1"` makes the button inaccessible for keyboard users.