### PR TITLE
UIPFPOL-29: Add interface version for inventory optimistic locking

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
       "finance.expense-classes": "1.0 2.0",
       "finance.funds": "1.4",
       "identifier-types": "1.2",
-      "inventory": "10.0",
+      "inventory": "10.0 11.0",
       "location-units": "2.0",
       "locations": "3.0",
       "material-types": "2.2",


### PR DESCRIPTION
Depend on the new inventory interface version for optimistic locking -
in addition to the old interface version.

This modules uses GET only, it doesn't PUT to inventory.
Therefore no code change is needed to support the
_version property in these records that are needed for
optimistic locking.