### PR TITLE
UIPFPOL-50: Support inventory 12.0 in okapiInterfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## (IN PROGRESS)
 
 * Find a purchase order line - Implement MCL Next/Previous pagination. Refs UIPFPOL-48.
+* Add version 12.0 for `inventory` interface. Refs UIPFPOL-50.
 
 ## [3.2.0](https://github.com/folio-org/ui-plugin-find-po-line/tree/v3.2.0) (2022-07-07)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-po-line/compare/v3.1.0...v3.2.0)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
       "finance.expense-classes": "2.0 3.0",
       "finance.funds": "1.4 2.0",
       "identifier-types": "1.2",
-      "inventory": "10.0 11.0",
+      "inventory": "10.0 11.0 12.0",
       "location-units": "2.0",
       "locations": "3.0",
       "material-types": "2.2",


### PR DESCRIPTION
Add version 12.0 to the list of supported inventory interface versions.

DELETE /inventory/instances and DELETE /inventory/items have been deleting all records.

MODINV-731 changed them to delete records by CQL, this requires a major interface version bump.

ui-plugin-find-po-line doesn't need any code change because it doesn't use these two DELETE APIs.