### PR TITLE
UIPFPOL-54 Upgrade react-redux to v8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-plugin-find-po-line
 
-## (IN PROGRESS)
+## (4.0.0 IN PROGRESS)
+* Bump stripes to `v8`. Upgrade `react-redux` to `v8`. Refs UIPFPOL-54.
 
 ## [3.3.0](https://github.com/folio-org/ui-plugin-find-po-line/tree/v3.3.0) (2022-10-21)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-po-line/compare/v3.2.0...v3.3.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/plugin-find-po-line",
-  "version": "3.3.0",
+  "version": "4.0.0",
   "description": "Find and select PO lines plugin for Stripes",
   "repository": "folio-org/ui-plugin-find-po-line",
   "publishConfig": {
@@ -55,7 +55,7 @@
     "@bigtest/mocha": "^0.5.2",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^6.1.0",
-    "@folio/stripes": "^7.0.0",
+    "@folio/stripes": "^8.0.0",
     "@folio/stripes-cli": "^2.4.0",
     "@formatjs/cli": "^4.2.16",
     "@testing-library/dom": "^7.29.6",
@@ -80,7 +80,7 @@
     "react-dom": "^17.0.2",
     "react-intl": "^5.8.1",
     "react-query": "^3.6.0",
-    "react-redux": "^7.2.2",
+    "react-redux": "^8.0.5",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "redux": "^4.0.0",
@@ -97,9 +97,9 @@
     "react-dom": "^17.0.2",
     "react-intl": "^5.8.1",
     "react-query": "^3.6.0",
-    "react-redux": "*",
+    "react-redux": "^8.0.5",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
-    "redux": "*"
+    "redux": "^4.0.0"
   }
 }


### PR DESCRIPTION
- Refs https://issues.folio.org/browse/UIPFPOL-54.
- Upgrade will be happening across all of Stripes framework and modules that reference react-redux.
- v7 to v8 is a very harmless upgrade and is only considered breaking since they removed a few rarely used functions (which I confirmed we don't use). See https://github.com/reduxjs/react-redux/releases/tag/v8.0.0 for more details.