### PR TITLE
UIPFPOL-73 Support filtering and searching for custom fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## (5.2.0 IN PROGRESS)
 
 * Align the `finance.fund` interface version (`3.0`). Refs UIPFPOL-68.
+* Add support for filtering and searching for custom fields. Refs UIPFPOL-73.
 
 ## [5.1.1](https://github.com/folio-org/ui-plugin-find-po-line/tree/v5.1.1) (2024-04-18)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-po-line/compare/v5.1.0...v5.1.1)

--- a/FindPOLine/OrderLinesFilters.js
+++ b/FindPOLine/OrderLinesFilters.js
@@ -8,6 +8,8 @@ import {
   AcqCheckboxFilter,
   AcqTagsFilter,
   AcqUnitFilter,
+  CUSTOM_FIELDS_FILTER,
+  CustomFieldsFilters,
   LocationFilterContainer,
   SourceFilter,
   ORDER_FORMAT_OPTIONS,
@@ -34,7 +36,14 @@ import { getDateRangeValueAsString } from './utils';
 
 const applyFiltersAdapter = (applyFilters) => ({ name, values }) => applyFilters(name, values);
 
-export function OrderLinesFilters({ activeFilters, applyFilters, disabled, funds = [], materialTypes = [] }) {
+export function OrderLinesFilters({
+  activeFilters,
+  applyFilters,
+  customFields,
+  disabled,
+  funds = [],
+  materialTypes = [],
+}) {
   const adaptedApplyFilters = useCallback(
     (filter) => applyFiltersAdapter(applyFilters)(filter),
     [applyFilters],
@@ -331,6 +340,14 @@ export function OrderLinesFilters({ activeFilters, applyFilters, disabled, funds
         name={FILTERS.DATE_UPDATED}
         onChange={handleDateRangeFilter}
       />
+      <CustomFieldsFilters
+        activeFilters={activeFilters}
+        customFields={customFields}
+        disabled={disabled}
+        id={CUSTOM_FIELDS_FILTER}
+        name={CUSTOM_FIELDS_FILTER}
+        onChange={adaptedApplyFilters}
+      />
     </AccordionSet>
   );
 }
@@ -338,6 +355,7 @@ export function OrderLinesFilters({ activeFilters, applyFilters, disabled, funds
 OrderLinesFilters.propTypes = {
   applyFilters: PropTypes.func.isRequired,
   activeFilters: PropTypes.object.isRequired,
+  customFields: PropTypes.arrayOf(PropTypes.object),
   disabled: PropTypes.bool,
   funds: PropTypes.arrayOf(PropTypes.object),
   materialTypes: PropTypes.arrayOf(PropTypes.object),

--- a/FindPOLine/OrderLinesFilters.js
+++ b/FindPOLine/OrderLinesFilters.js
@@ -6,20 +6,20 @@ import {
 } from '@folio/stripes/components';
 import {
   AcqCheckboxFilter,
+  AcqDateRangeFilter,
   AcqTagsFilter,
   AcqUnitFilter,
+  BooleanFilter,
   CUSTOM_FIELDS_FILTER,
   CustomFieldsFilters,
-  LocationFilterContainer,
-  SourceFilter,
-  ORDER_FORMAT_OPTIONS,
-  PluggableOrganizationFilter,
-  AcqDateRangeFilter,
-  BooleanFilter,
-  FundFilter,
   ExpenseClassFilter,
+  FundFilter,
+  LocationFilterContainer,
+  ORDER_FORMAT_OPTIONS,
   PluggableDonorsFilter,
+  PluggableOrganizationFilter,
   PluggableUserFilter,
+  SourceFilter,
 } from '@folio/stripes-acq-components';
 
 import AcqMethodsFilter from './AcqMethodsFilter';

--- a/FindPOLine/OrderLinesFilters.test.js
+++ b/FindPOLine/OrderLinesFilters.test.js
@@ -1,7 +1,14 @@
 import { QueryClient, QueryClientProvider } from 'react-query';
 
-import { act, render, screen } from '@folio/jest-config-stripes/testing-library/react';
-import { AcqDateRangeFilter, CUSTOM_FIELDS_FIXTURE } from '@folio/stripes-acq-components';
+import {
+  act,
+  render,
+  screen,
+} from '@folio/jest-config-stripes/testing-library/react';
+import {
+  AcqDateRangeFilter,
+  CUSTOM_FIELDS_FIXTURE,
+} from '@folio/stripes-acq-components';
 
 import { OrderLinesFilters } from './OrderLinesFilters';
 

--- a/FindPOLine/OrderLinesFilters.test.js
+++ b/FindPOLine/OrderLinesFilters.test.js
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from 'react-query';
 
-import { render, act } from '@folio/jest-config-stripes/testing-library/react';
-import { AcqDateRangeFilter } from '@folio/stripes-acq-components';
+import { act, render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import { AcqDateRangeFilter, CUSTOM_FIELDS_FIXTURE } from '@folio/stripes-acq-components';
 
 import { OrderLinesFilters } from './OrderLinesFilters';
 
@@ -68,5 +68,15 @@ describe('OrderLinesFilters component', () => {
       AcqDateRangeFilter.mock.calls[0][0].onChange(filterValues);
     });
     expect(applyFilters).toHaveBeenCalledWith(filterValues.name, filterValues.values[0]);
+  });
+
+  it('should display correct filters for custom fields', () => {
+    renderOrderLinesFilters({ 'customFields': CUSTOM_FIELDS_FIXTURE });
+
+    expect(screen.getByText('stripes-smart-components.customFields Datepicker')).toBeInTheDocument();
+    expect(screen.getByText('stripes-smart-components.customFields Singleselect')).toBeInTheDocument();
+    expect(screen.getByText('stripes-smart-components.customFields Multiselect')).toBeInTheDocument();
+    expect(screen.queryByText('stripes-smart-components.customFields Long text')).toBeNull();
+    expect(screen.queryByText('stripes-smart-components.customFields Short text')).toBeNull();
   });
 });

--- a/FindPOLine/OrderLinesSearchConfig.js
+++ b/FindPOLine/OrderLinesSearchConfig.js
@@ -1,3 +1,5 @@
+import moment from 'moment';
+
 import {
   CUSTOM_FIELDS_FILTER,
   CUSTOM_FIELDS_TYPES,
@@ -5,7 +7,6 @@ import {
   generateQueryTemplate,
   getCustomFieldsKeywordIndexes,
 } from '@folio/stripes-acq-components';
-import moment from 'moment';
 
 const indexes = [
   'contributors',

--- a/FindPOLine/OrderLinesSearchConfig.js
+++ b/FindPOLine/OrderLinesSearchConfig.js
@@ -1,5 +1,4 @@
-import moment from 'moment';
-
+import { dayjs } from '@folio/stripes/components';
 import {
   CUSTOM_FIELDS_FILTER,
   CUSTOM_FIELDS_TYPES,
@@ -42,7 +41,7 @@ export const getCqlQuery = (query, sIndex, localeDateFormat, customFields) => {
   );
 
   if (customField?.type === CUSTOM_FIELDS_TYPES.DATE_PICKER) {
-    const isoDate = moment.utc(query, localeDateFormat).format(DATE_FORMAT);
+    const isoDate = dayjs.utc(query, localeDateFormat).format(DATE_FORMAT);
 
     return `${isoDate}*`;
   }

--- a/FindPOLine/utils.js
+++ b/FindPOLine/utils.js
@@ -12,7 +12,10 @@ import {
 } from '@folio/stripes-acq-components';
 
 import { FILTERS, QUALIFIER_SEPARATOR } from './constants';
-import { getCqlQuery, getKeywordQuery } from './OrderLinesSearchConfig';
+import {
+  getCqlQuery,
+  getKeywordQuery,
+} from './OrderLinesSearchConfig';
 
 const defaultSearchFn = (localeDateFormat, customFields = []) => (query, qindex) => {
   if (qindex === 'details.productIds') {

--- a/FindPOLine/utils.js
+++ b/FindPOLine/utils.js
@@ -5,25 +5,28 @@ import {
   buildFilterQuery,
   buildSortingQuery,
   connectQuery,
+  getCustomFieldsFilterMap,
+  IDENTIFIER_TYPES_API,
   SEARCH_INDEX_PARAMETER,
   SEARCH_PARAMETER,
-  IDENTIFIER_TYPES_API,
 } from '@folio/stripes-acq-components';
 
 import { FILTERS, QUALIFIER_SEPARATOR } from './constants';
-import { getKeywordQuery } from './OrderLinesSearchConfig';
+import { getCqlQuery, getKeywordQuery } from './OrderLinesSearchConfig';
 
-function defaultSearchFn(query, qindex) {
+const defaultSearchFn = (localeDateFormat, customFields = []) => (query, qindex) => {
   if (qindex === 'details.productIds') {
     return `details.productIds = "/@productId = "${query}"* `;
   }
 
   if (qindex) {
-    return `(${qindex}=="*${query}*")`;
+    const cqlQuery = getCqlQuery(query, qindex, localeDateFormat, customFields);
+
+    return `(${qindex}==${cqlQuery})`;
   }
 
-  return getKeywordQuery(query);
-}
+  return getKeywordQuery(query, localeDateFormat, customFields);
+};
 
 export const getDateRangeValueAsString = (filterValue = '') => {
   if (Array.isArray(filterValue)) {
@@ -33,10 +36,10 @@ export const getDateRangeValueAsString = (filterValue = '') => {
   return filterValue;
 };
 
-export const buildOrderLinesQuery = (queryParams, isbnId, normalizedISBN) => {
+export const buildOrderLinesQuery = (queryParams, isbnId, normalizedISBN, localeDateFormat, customFields) => {
   const searchFn = normalizedISBN
     ? () => `details.productIds all \\"productId\\": \\"${normalizedISBN}\\"  AND details.productIds all  \\"productIdType\\": \\"${isbnId}\\"`
-    : defaultSearchFn;
+    : defaultSearchFn(localeDateFormat, customFields);
 
   const queryParamsFilterQuery = buildFilterQuery(
     queryParams,
@@ -67,6 +70,7 @@ export const buildOrderLinesQuery = (queryParams, isbnId, normalizedISBN) => {
       [FILTERS.ACCESS_PROVIDER]: (filterValue) => `eresource.${FILTERS.ACCESS_PROVIDER} == ${filterValue}`,
       [FILTERS.ACTIVATED]: (filterValue) => `eresource.${FILTERS.ACTIVATED} == ${filterValue}`,
       [FILTERS.TRIAL]: (filterValue) => `eresource.${FILTERS.TRIAL} == ${filterValue}`,
+      ...getCustomFieldsFilterMap(customFields),
     },
   );
 
@@ -94,7 +98,7 @@ export const getNormalizedISBN = async (isbnNumber, ky) => {
   }
 };
 
-export function getLinesQuery(queryParams, ky) {
+export function getLinesQuery(queryParams, ky, localeDateFormat, customFields) {
   const isISBNSearch = queryParams[SEARCH_INDEX_PARAMETER] === 'productIdISBN';
   const isbnNumber = queryParams[SEARCH_PARAMETER]?.split(QUALIFIER_SEPARATOR)[0];
 
@@ -103,6 +107,6 @@ export function getLinesQuery(queryParams, ky) {
 
     if (isbnData?.isError) return undefined;
 
-    return buildOrderLinesQuery(queryParams, isbnData?.isbn, isbnData?.isbnType);
+    return buildOrderLinesQuery(queryParams, isbnData?.isbn, isbnData?.isbnType, localeDateFormat, customFields);
   };
 }

--- a/FindPOLine/utils.test.js
+++ b/FindPOLine/utils.test.js
@@ -66,7 +66,7 @@ describe('Utils', () => {
         CUSTOM_FIELDS_FIXTURE,
       );
       const parts = [
-        'datepicker=="Invalid date*"',
+        'datepicker=="Invalid Date*"',
         'shorttext=="*abc*"',
         'longtext=="*abc*"',
       ].map((s) => `${CUSTOM_FIELDS_FILTER}.${s}`);

--- a/FindPOLine/utils.test.js
+++ b/FindPOLine/utils.test.js
@@ -1,3 +1,10 @@
+import {
+  CUSTOM_FIELDS_FILTER,
+  CUSTOM_FIELDS_FIXTURE,
+  SEARCH_INDEX_PARAMETER,
+  SEARCH_PARAMETER,
+} from '@folio/stripes-acq-components';
+
 import { FILTERS } from './constants';
 import {
   buildOrderLinesQuery,
@@ -17,6 +24,54 @@ describe('Utils', () => {
       const query = buildOrderLinesQuery({ [FILTERS.LOCATION]: 'locationId' });
 
       expect(query).toContain('(locations=="*locationId*" or searchLocationIds=="*locationId*")');
+    });
+
+    it('should return filter query based on datepicker custom field', () => {
+      const query = buildOrderLinesQuery(
+        { [`${CUSTOM_FIELDS_FILTER}.datepicker`]: '04-01-2020:04-30-2020' },
+        null,
+        null,
+        'MM/DD/YYYY',
+        CUSTOM_FIELDS_FIXTURE,
+      );
+
+      expect(query).toContain(
+        `(${CUSTOM_FIELDS_FILTER}.datepicker>="2020-04-01T00:00:00.000" ` +
+        'and ' +
+        `${CUSTOM_FIELDS_FILTER}.datepicker<="2020-04-30T23:59:59.999")`,
+      );
+    });
+
+    it('should return keyword query based on datepicker custom field', () => {
+      const query = buildOrderLinesQuery(
+        {
+          [SEARCH_INDEX_PARAMETER]: `${CUSTOM_FIELDS_FILTER}.datepicker`,
+          [SEARCH_PARAMETER]: '01/30/2021',
+        },
+        null,
+        null,
+        'MM/DD/YYYY',
+        CUSTOM_FIELDS_FIXTURE,
+      );
+
+      expect(query).toContain('(customFields.datepicker==2021-01-30*)');
+    });
+
+    it('should return keyword query with custom fields indexes', () => {
+      const query = buildOrderLinesQuery(
+        { [SEARCH_PARAMETER]: 'abc' },
+        null,
+        null,
+        'MM/DD/YYYY',
+        CUSTOM_FIELDS_FIXTURE,
+      );
+      const parts = [
+        'datepicker=="Invalid date*"',
+        'shorttext=="*abc*"',
+        'longtext=="*abc*"',
+      ].map((s) => `${CUSTOM_FIELDS_FILTER}.${s}`);
+
+      expect(parts.every(s => query.includes(s))).toBe(true);
     });
   });
 });


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIPFPOL-73

Updates `<OrderLinesFilters>`, `getLinesQuery` and `buildOrderLinesQuery` to handle custom fields props/parameters.
* These changes are required to implement filtering and searching for custom fields on order lines in `ui-orders`.
* These changes will not alter the functionality of the plugin itself.