### PR TITLE
UIPFPOL-74 Display affiliation selection in all places where plugin is used

### DIFF
--- a/FindPOLine/FindPOLine.js
+++ b/FindPOLine/FindPOLine.js
@@ -1,14 +1,23 @@
-import React, { useState, useCallback } from 'react';
+import get from 'lodash/get';
+import isUndefined from 'lodash/isUndefined';
 import PropTypes from 'prop-types';
+import {
+  useState,
+  useCallback,
+} from 'react';
 import { FormattedMessage } from 'react-intl';
-import { get } from 'lodash';
 
 import { NoValue } from '@folio/stripes/components';
+import {
+  checkIfUserInCentralTenant,
+  useStripes,
+} from '@folio/stripes/core';
 import {
   AmountWithCurrencyField,
   FindRecords,
   FolioFormattedDate,
   PLUGIN_RESULT_COUNT_INCREMENT,
+  useCentralOrderingSettings,
   useFunds,
 } from '@folio/stripes-acq-components';
 
@@ -60,10 +69,12 @@ const INIT_PAGINATION = { limit: PLUGIN_RESULT_COUNT_INCREMENT, offset: 0 };
 
 const FindPOLine = ({
   addLines,
-  crossTenant = false,
+  crossTenant: crossTenantProp,
   isSingleSelect,
   ...rest
 }) => {
+  const stripes = useStripes();
+
   const [totalCount, setTotalCount] = useState(0);
   const [records, setRecords] = useState([]);
   const [searchParams, setSearchParams] = useState({});
@@ -71,6 +82,14 @@ const FindPOLine = ({
   const { funds } = useFunds();
   const { materialTypes } = useMaterialTypes();
   const [pagination, setPagination] = useState(INIT_PAGINATION);
+
+  const { enabled: isCentralOrderingEnabled } = useCentralOrderingSettings({
+    enabled: isUndefined(crossTenantProp) && checkIfUserInCentralTenant(stripes),
+  });
+
+  const crossTenant = isUndefined(crossTenantProp)
+    ? isCentralOrderingEnabled
+    : crossTenantProp;
 
   const { fetchOrderLines } = useFetchOrderLines();
 

--- a/FindPOLine/FindPOLine.test.js
+++ b/FindPOLine/FindPOLine.test.js
@@ -4,6 +4,7 @@ import FindPOLine from './FindPOLine';
 
 jest.mock('@folio/stripes-acq-components', () => ({
   ...jest.requireActual('@folio/stripes-acq-components'),
+  useCentralOrderingSettings: jest.fn(() => ({ enabled: false })),
   useFunds: jest.fn().mockReturnValue({ funds: [] }),
 }));
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UIPFPOL-74

Updated requirement: https://folio-org.atlassian.net/browse/UIPFPOL-74?focusedCommentId=210534

Initial PR: #159

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
According to the PO's clarification, by default, the location filter in the plugin should display the affiliation selection in the location lookup when a user is in the central tenant and the "Central Ordering" setting is active.

## Screenshot

https://github.com/folio-org/ui-plugin-find-po-line/assets/88109087/ff335d25-958d-4765-9b94-05b694644108


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
