### PR TITLE
UIPFPOL-90 enabling the deactivation of obsolete order suffix and prefix values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## (6.1.0 IN PROGRESS)
 
+* Add hints for deprecated suffixes and prefixes in filters for search. Refs UIOR-1450.
+
 ## [6.0.1](https://github.com/folio-org/ui-plugin-find-po-line/tree/v6.0.1) (2025-04-04)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-po-line/compare/v6.0.0...v6.0.1)
 

--- a/FindPOLine/PrefixFilter/PrefixFilter.js
+++ b/FindPOLine/PrefixFilter/PrefixFilter.js
@@ -11,11 +11,7 @@ function PrefixFilter({ tenantId, ...rest }) {
   const { prefixes } = usePrefixes({ tenantId });
   const intl = useIntl();
 
-  const deprecatedText = intl.formatMessage({
-    id: "ui-plugin-find-po-line.filter.prefixFilter.deprecated",
-  });
-
-  const options = getPrefixSuffixOptions(prefixes, deprecatedText);
+  const options = getPrefixSuffixOptions(prefixes, intl);
 
   return (
     <SelectionFilter

--- a/FindPOLine/PrefixFilter/PrefixFilter.js
+++ b/FindPOLine/PrefixFilter/PrefixFilter.js
@@ -5,12 +5,12 @@ import { useIntl } from 'react-intl';
 import { SelectionFilter } from '@folio/stripes-acq-components';
 
 import { usePrefixes } from '../hooks';
-import { getPrefixSuffixOptions } from '../utils';
+import { getPrefixOptions } from '../utils';
 
 function PrefixFilter({ tenantId, ...rest }) {
   const { prefixes } = usePrefixes({ tenantId });
   const intl = useIntl();
-  const options = getPrefixSuffixOptions(prefixes, intl);
+  const options = useMemo(() => getPrefixOptions(prefixes, intl), [prefixes, intl]);
 
   return (
     <SelectionFilter

--- a/FindPOLine/PrefixFilter/PrefixFilter.js
+++ b/FindPOLine/PrefixFilter/PrefixFilter.js
@@ -4,14 +4,20 @@ import { useMemo } from 'react';
 import { SelectionFilter } from '@folio/stripes-acq-components';
 
 import { usePrefixes } from '../hooks';
+import { useIntl } from 'react-intl';
 
 function PrefixFilter({ tenantId, ...rest }) {
   const { prefixes } = usePrefixes({ tenantId });
+  const intl = useIntl();
+
+  const deprecatedText = intl.formatMessage({
+    id: "ui-plugin-find-po-line.filter.prefixFilter.deprecated",
+  });
 
   const options = useMemo(
     () =>
       prefixes.map(({ name, deprecated }) => ({
-        label: deprecated ? `${name} (deprecated)` : name,
+        label: deprecated ? `${name} (${deprecatedText})` : name,
         value: name,
       })),
     [prefixes],

--- a/FindPOLine/PrefixFilter/PrefixFilter.js
+++ b/FindPOLine/PrefixFilter/PrefixFilter.js
@@ -1,16 +1,15 @@
 import PropTypes from 'prop-types';
 import { useMemo } from 'react';
+import { useIntl } from 'react-intl';
 
 import { SelectionFilter } from '@folio/stripes-acq-components';
 
 import { usePrefixes } from '../hooks';
-import { useIntl } from 'react-intl';
 import { getPrefixSuffixOptions } from '../utils';
 
 function PrefixFilter({ tenantId, ...rest }) {
   const { prefixes } = usePrefixes({ tenantId });
   const intl = useIntl();
-
   const options = getPrefixSuffixOptions(prefixes, intl);
 
   return (

--- a/FindPOLine/PrefixFilter/PrefixFilter.js
+++ b/FindPOLine/PrefixFilter/PrefixFilter.js
@@ -5,6 +5,7 @@ import { SelectionFilter } from '@folio/stripes-acq-components';
 
 import { usePrefixes } from '../hooks';
 import { useIntl } from 'react-intl';
+import { getPrefixSuffixOptions } from '../utils';
 
 function PrefixFilter({ tenantId, ...rest }) {
   const { prefixes } = usePrefixes({ tenantId });
@@ -14,14 +15,7 @@ function PrefixFilter({ tenantId, ...rest }) {
     id: "ui-plugin-find-po-line.filter.prefixFilter.deprecated",
   });
 
-  const options = useMemo(
-    () =>
-      prefixes.map(({ name, deprecated }) => ({
-        label: deprecated ? `${name} (${deprecatedText})` : name,
-        value: name,
-      })),
-    [prefixes],
-  );
+  const options = getPrefixSuffixOptions(prefixes, deprecatedText);
 
   return (
     <SelectionFilter

--- a/FindPOLine/PrefixFilter/PrefixFilter.js
+++ b/FindPOLine/PrefixFilter/PrefixFilter.js
@@ -8,7 +8,14 @@ import { usePrefixes } from '../hooks';
 function PrefixFilter({ tenantId, ...rest }) {
   const { prefixes } = usePrefixes({ tenantId });
 
-  const options = useMemo(() => prefixes.map(({ name }) => ({ label: name, value: name })), [prefixes]);
+  const options = useMemo(
+    () =>
+      prefixes.map(({ name, deprecated }) => ({
+        label: deprecated ? `${name} (deprecated)` : name,
+        value: name,
+      })),
+    [prefixes],
+  );
 
   return (
     <SelectionFilter

--- a/FindPOLine/SuffixFilter/SuffixFilter.js
+++ b/FindPOLine/SuffixFilter/SuffixFilter.js
@@ -4,11 +4,24 @@ import { useMemo } from 'react';
 import { SelectionFilter } from '@folio/stripes-acq-components';
 
 import { useSuffixes } from '../hooks';
+import { useIntl } from 'react-intl';
 
 const SuffixFilter = ({ tenantId, ...rest }) => {
   const { suffixes } = useSuffixes({ tenantId });
+  const intl = useIntl();
 
-  const options = useMemo(() => suffixes.map(({ name }) => ({ label: name, value: name })), [suffixes]);
+  const deprecatedText = intl.formatMessage({
+    id: "ui-plugin-find-po-line.filter.suffixFilter.deprecated",
+  });
+
+  const options = useMemo(
+    () =>
+      suffixes.map(({ name, deprecated }) => ({
+        label: deprecated ? `${name} (${deprecatedText})` : name,
+        value: name,
+      })),
+    [suffixes],
+  );
 
   return (
     <SelectionFilter

--- a/FindPOLine/SuffixFilter/SuffixFilter.js
+++ b/FindPOLine/SuffixFilter/SuffixFilter.js
@@ -11,11 +11,7 @@ const SuffixFilter = ({ tenantId, ...rest }) => {
   const { suffixes } = useSuffixes({ tenantId });
   const intl = useIntl();
 
-  const deprecatedText = intl.formatMessage({
-    id: "ui-plugin-find-po-line.filter.suffixFilter.deprecated",
-  });
-
-  const options = getPrefixSuffixOptions(suffixes, deprecatedText);
+  const options = getPrefixSuffixOptions(suffixes, intl);
 
   return (
     <SelectionFilter

--- a/FindPOLine/SuffixFilter/SuffixFilter.js
+++ b/FindPOLine/SuffixFilter/SuffixFilter.js
@@ -1,16 +1,15 @@
 import PropTypes from 'prop-types';
 import { useMemo } from 'react';
+import { useIntl } from 'react-intl';
 
 import { SelectionFilter } from '@folio/stripes-acq-components';
 
 import { useSuffixes } from '../hooks';
-import { useIntl } from 'react-intl';
 import { getPrefixSuffixOptions } from '../utils';
 
 const SuffixFilter = ({ tenantId, ...rest }) => {
   const { suffixes } = useSuffixes({ tenantId });
   const intl = useIntl();
-
   const options = getPrefixSuffixOptions(suffixes, intl);
 
   return (

--- a/FindPOLine/SuffixFilter/SuffixFilter.js
+++ b/FindPOLine/SuffixFilter/SuffixFilter.js
@@ -5,12 +5,12 @@ import { useIntl } from 'react-intl';
 import { SelectionFilter } from '@folio/stripes-acq-components';
 
 import { useSuffixes } from '../hooks';
-import { getPrefixSuffixOptions } from '../utils';
+import { getSuffixOptions } from '../utils';
 
 const SuffixFilter = ({ tenantId, ...rest }) => {
   const { suffixes } = useSuffixes({ tenantId });
   const intl = useIntl();
-  const options = getPrefixSuffixOptions(suffixes, intl);
+  const options = useMemo(() => getSuffixOptions(suffixes, intl), [suffixes, intl]);
 
   return (
     <SelectionFilter

--- a/FindPOLine/SuffixFilter/SuffixFilter.js
+++ b/FindPOLine/SuffixFilter/SuffixFilter.js
@@ -5,6 +5,7 @@ import { SelectionFilter } from '@folio/stripes-acq-components';
 
 import { useSuffixes } from '../hooks';
 import { useIntl } from 'react-intl';
+import { getPrefixSuffixOptions } from '../utils';
 
 const SuffixFilter = ({ tenantId, ...rest }) => {
   const { suffixes } = useSuffixes({ tenantId });
@@ -14,14 +15,7 @@ const SuffixFilter = ({ tenantId, ...rest }) => {
     id: "ui-plugin-find-po-line.filter.suffixFilter.deprecated",
   });
 
-  const options = useMemo(
-    () =>
-      suffixes.map(({ name, deprecated }) => ({
-        label: deprecated ? `${name} (${deprecatedText})` : name,
-        value: name,
-      })),
-    [suffixes],
-  );
+  const options = getPrefixSuffixOptions(suffixes, deprecatedText);
 
   return (
     <SelectionFilter

--- a/FindPOLine/utils.js
+++ b/FindPOLine/utils.js
@@ -129,8 +129,18 @@ export function getLinesQuery(queryParams, ky, localeDateFormat, customFields) {
   };
 }
 
-export const getPrefixSuffixOptions = (records, deprecatedText) =>
-    records.map(({ name, deprecated }) => ({
-        label: deprecated ? `${name} (${deprecatedText})` : name,
-        value: name,
-      }));
+export const getPrefixSuffixOptions = (records, intl) =>
+  records.map(({ name, deprecated }) => {
+    const deprecatedText = intl.formatMessage(
+      {
+        id: 'ui-plugin-find-po-line.filter.suffixFilter.deprecated',
+      },
+      {
+        name: name,
+      },
+    );
+    return {
+      label: deprecated ? deprecatedText : name,
+      value: name,
+    };
+  });

--- a/FindPOLine/utils.js
+++ b/FindPOLine/utils.js
@@ -129,18 +129,20 @@ export function getLinesQuery(queryParams, ky, localeDateFormat, customFields) {
   };
 }
 
-export const getPrefixSuffixOptions = (records, intl) =>
+export const getPrefixSuffixOptions = (records, intl) => (
   records.map(({ name, deprecated }) => {
     const deprecatedText = intl.formatMessage(
       {
         id: 'ui-plugin-find-po-line.filter.suffixFilter.deprecated',
       },
       {
-        name: name,
+        name,
       },
     );
+
     return {
       label: deprecated ? deprecatedText : name,
       value: name,
     };
-  });
+  })
+);

--- a/FindPOLine/utils.js
+++ b/FindPOLine/utils.js
@@ -80,7 +80,7 @@ export const buildOrderLinesQuery = (queryParams, isbnId, normalizedISBN, locale
         [FILTERS.LOCATION, 'searchLocationIds']
           .map((filterKey) => buildArrayFieldQuery(filterKey, filterValue))
           .join(' or ')
-      })`,
+        })`,
       [FILTERS.DONOR]: buildArrayFieldQuery.bind(null, [FILTERS.DONOR]),
       [FILTERS.ACQUISITIONS_UNIT]: buildArrayFieldQuery.bind(null, [FILTERS.ACQUISITIONS_UNIT]),
       [FILTERS.MATERIAL_TYPE_PHYSICAL]: (filterValue) => `physical.materialType == ${filterValue}`,
@@ -129,20 +129,56 @@ export function getLinesQuery(queryParams, ky, localeDateFormat, customFields) {
   };
 }
 
-export const getPrefixSuffixOptions = (records, intl) => (
-  records.map(({ name, deprecated }) => {
-    const deprecatedText = intl.formatMessage(
-      {
-        id: 'ui-plugin-find-po-line.filter.suffixFilter.deprecated',
-      },
-      {
-        name,
-      },
-    );
-
+/**
+ * Generate options with deprecated labels for a dropdown.
+ * @param {object[]} records - array of json objects with { name, deprecated }
+ * @param {class} intl - class for internationalization
+ * @param {string} deprecatedMessageId - intl message ID for labels
+ * @returns {object[]} array of {label, value} pairs.
+ */
+const generateOptionsWithDeprecationLabels = (
+  records,
+  intl,
+  deprecatedMessageId,
+) => records
+  .map(({ name, deprecated }) => {
     return {
-      label: deprecated ? deprecatedText : name,
+      label: deprecated
+        ? intl.formatMessage({ id: deprecatedMessageId }, { name })
+        : name,
       value: name,
     };
-  })
+  });
+
+/**
+ * Calculate the options of a prefix to use in a dropdown.
+ * https://github.com/folio-org/acq-models/blob/master/mod-orders-storage/schemas/prefix.json
+ * @param {object[]} records - array of json objects (prefix) with { name, deprecated }
+ * @param {string} initialSelectedValue - the value of the dropdown on initialization
+ * @param {class} intl - class for internationalization
+ * @returns {object[]} array of {label, value} pairs.
+ */
+export const getPrefixOptions = (
+  records,
+  intl,
+) => generateOptionsWithDeprecationLabels(
+  records,
+  intl,
+  'ui-plugin-find-po-line.filter.prefixFilter.deprecated',
+);
+
+/**
+ * Calculate the options of a suffix to use in a dropdown.
+ * https://github.com/folio-org/acq-models/blob/master/mod-orders-storage/schemas/suffix.json
+ * @param {object[]} records - array of json objects (suffix) with { name, deprecated }
+ * @param {class} intl - class for internationalization
+ * @returns {object[]} array of {label, value} pairs.
+ */
+export const getSuffixOptions = (
+  records,
+  intl,
+) => generateOptionsWithDeprecationLabels(
+  records,
+  intl,
+  'ui-plugin-find-po-line.filter.suffixFilter.deprecated',
 );

--- a/FindPOLine/utils.js
+++ b/FindPOLine/utils.js
@@ -80,7 +80,7 @@ export const buildOrderLinesQuery = (queryParams, isbnId, normalizedISBN, locale
         [FILTERS.LOCATION, 'searchLocationIds']
           .map((filterKey) => buildArrayFieldQuery(filterKey, filterValue))
           .join(' or ')
-        })`,
+      })`,
       [FILTERS.DONOR]: buildArrayFieldQuery.bind(null, [FILTERS.DONOR]),
       [FILTERS.ACQUISITIONS_UNIT]: buildArrayFieldQuery.bind(null, [FILTERS.ACQUISITIONS_UNIT]),
       [FILTERS.MATERIAL_TYPE_PHYSICAL]: (filterValue) => `physical.materialType == ${filterValue}`,

--- a/FindPOLine/utils.js
+++ b/FindPOLine/utils.js
@@ -128,3 +128,9 @@ export function getLinesQuery(queryParams, ky, localeDateFormat, customFields) {
     return buildOrderLinesQuery(queryParams, isbnData?.isbn, isbnData?.isbnType, localeDateFormat, customFields);
   };
 }
+
+export const getPrefixSuffixOptions = (records, deprecatedText) =>
+    records.map(({ name, deprecated }) => ({
+        label: deprecated ? `${name} (${deprecatedText})` : name,
+        value: name,
+      }));

--- a/FindPOLine/utils.test.js
+++ b/FindPOLine/utils.test.js
@@ -6,11 +6,17 @@ import {
 } from '@folio/stripes-acq-components';
 
 import { FILTERS } from './constants';
+import { useIntl } from 'react-intl';
 import {
   buildOrderLinesQuery,
   getDateRangeValueAsString,
   getPrefixSuffixOptions
 } from './utils';
+
+jest.mock('react-intl', () => ({
+  ...jest.requireActual('react-intl'),
+  useIntl: jest.fn(),
+}));
 
 describe('Utils', () => {
   describe('getDateRangeValueAsString', () => {
@@ -78,42 +84,53 @@ describe('Utils', () => {
 });
 
 describe('getPrefixSuffixOptions', () => {
+  beforeEach(() => {
+    useIntl.mockReturnValue({
+      formatMessage: ({ }, { name }) => `${name} (deprecated)`,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+
   it('should show a hint for deprecated prefixes', () => {
     const records = [
-        {
-            "id": "db9f5d17-0ca3-4d14-ae49-16b63c8fc083",
-            "name": "pref",
-            "description": "Prefix for test purposes",
-            "deprecated": false
-        },
-        {
-            "id": "a91e8e98-2e83-4e05-abc7-908ba801edb0",
-            "name": "pref2",
-            "description": "test deprecated",
-            "deprecated": true
-        },
-        {
-            "id": "7daa881b-4209-44a1-8f37-2388385783b0",
-            "name": "pref3",
-            "description": "test deprecated",
-            "deprecated": false
-        }
+      {
+        id: 'db9f5d17-0ca3-4d14-ae49-16b63c8fc083',
+        name: 'pref',
+        description: 'Prefix for test purposes',
+        deprecated: false,
+      },
+      {
+        id: 'a91e8e98-2e83-4e05-abc7-908ba801edb0',
+        name: 'pref2',
+        description: 'test deprecated',
+        deprecated: true,
+      },
+      {
+        id: '7daa881b-4209-44a1-8f37-2388385783b0',
+        name: 'pref3',
+        description: 'test deprecated',
+        deprecated: false,
+      },
     ];
-    const deprecatedText = 'deprecated';
-    const actual = getPrefixSuffixOptions(records, deprecatedText);
+    const intl = useIntl();
+    const actual = getPrefixSuffixOptions(records, intl);
     const expected = [
       {
-          "label": "pref",
-          "value": "pref"
+        label: 'pref',
+        value: 'pref',
       },
       {
-          "label": "pref2 (deprecated)",
-          "value": "pref2"
+        label: 'pref2 (deprecated)',
+        value: 'pref2',
       },
       {
-          "label": "pref3",
-          "value": "pref3"
-      }
+        label: 'pref3',
+        value: 'pref3',
+      },
     ];
     expect(actual).toEqual(expected);
   });

--- a/FindPOLine/utils.test.js
+++ b/FindPOLine/utils.test.js
@@ -1,3 +1,4 @@
+import { useIntl } from 'react-intl';
 import {
   CUSTOM_FIELDS_FILTER,
   CUSTOM_FIELDS_FIXTURE,
@@ -6,11 +7,10 @@ import {
 } from '@folio/stripes-acq-components';
 
 import { FILTERS } from './constants';
-import { useIntl } from 'react-intl';
 import {
   buildOrderLinesQuery,
   getDateRangeValueAsString,
-  getPrefixSuffixOptions
+  getPrefixSuffixOptions,
 } from './utils';
 
 jest.mock('react-intl', () => ({
@@ -86,14 +86,13 @@ describe('Utils', () => {
 describe('getPrefixSuffixOptions', () => {
   beforeEach(() => {
     useIntl.mockReturnValue({
-      formatMessage: ({ }, { name }) => `${name} (deprecated)`,
+      formatMessage: (_, { name }) => `${name} (deprecated)`,
     });
   });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
-
 
   it('should show a hint for deprecated prefixes', () => {
     const records = [
@@ -132,6 +131,7 @@ describe('getPrefixSuffixOptions', () => {
         value: 'pref3',
       },
     ];
+
     expect(actual).toEqual(expected);
   });
 });

--- a/FindPOLine/utils.test.js
+++ b/FindPOLine/utils.test.js
@@ -9,6 +9,7 @@ import { FILTERS } from './constants';
 import {
   buildOrderLinesQuery,
   getDateRangeValueAsString,
+  getPrefixSuffixOptions
 } from './utils';
 
 describe('Utils', () => {
@@ -73,5 +74,47 @@ describe('Utils', () => {
 
       expect(parts.every(s => query.includes(s))).toBe(true);
     });
+  });
+});
+
+describe('getPrefixSuffixOptions', () => {
+  it('should show a hint for deprecated prefixes', () => {
+    const records = [
+        {
+            "id": "db9f5d17-0ca3-4d14-ae49-16b63c8fc083",
+            "name": "pref",
+            "description": "Prefix for test purposes",
+            "deprecated": false
+        },
+        {
+            "id": "a91e8e98-2e83-4e05-abc7-908ba801edb0",
+            "name": "pref2",
+            "description": "test deprecated",
+            "deprecated": true
+        },
+        {
+            "id": "7daa881b-4209-44a1-8f37-2388385783b0",
+            "name": "pref3",
+            "description": "test deprecated",
+            "deprecated": false
+        }
+    ];
+    const deprecatedText = 'deprecated';
+    const actual = getPrefixSuffixOptions(records, deprecatedText);
+    const expected = [
+      {
+          "label": "pref",
+          "value": "pref"
+      },
+      {
+          "label": "pref2 (deprecated)",
+          "value": "pref2"
+      },
+      {
+          "label": "pref3",
+          "value": "pref3"
+      }
+    ];
+    expect(actual).toEqual(expected);
   });
 });

--- a/FindPOLine/utils.test.js
+++ b/FindPOLine/utils.test.js
@@ -10,7 +10,8 @@ import { FILTERS } from './constants';
 import {
   buildOrderLinesQuery,
   getDateRangeValueAsString,
-  getPrefixSuffixOptions,
+  getPrefixOptions,
+  getSuffixOptions,
 } from './utils';
 
 jest.mock('react-intl', () => ({
@@ -83,7 +84,7 @@ describe('Utils', () => {
   });
 });
 
-describe('getPrefixSuffixOptions', () => {
+describe('getPrefixOptions', () => {
   beforeEach(() => {
     useIntl.mockReturnValue({
       formatMessage: (_, { name }) => `${name} (deprecated)`,
@@ -116,7 +117,7 @@ describe('getPrefixSuffixOptions', () => {
       },
     ];
     const intl = useIntl();
-    const actual = getPrefixSuffixOptions(records, intl);
+    const actual = getPrefixOptions(records, intl);
     const expected = [
       {
         label: 'pref',
@@ -129,6 +130,59 @@ describe('getPrefixSuffixOptions', () => {
       {
         label: 'pref3',
         value: 'pref3',
+      },
+    ];
+
+    expect(actual).toEqual(expected);
+  });
+});
+
+describe('getSuffixOptions', () => {
+  beforeEach(() => {
+    useIntl.mockReturnValue({
+      formatMessage: (_, { name }) => `${name} (deprecated)`,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should show a hint for deprecated suffixes', () => {
+    const records = [
+      {
+        id: 'db9f5d17-0ca3-4d14-ae49-16b63c8fc083',
+        name: 'suf',
+        description: 'Suffix for test purposes',
+        deprecated: false,
+      },
+      {
+        id: 'a91e8e98-2e83-4e05-abc7-908ba801edb0',
+        name: 'suf2',
+        description: 'test deprecated',
+        deprecated: true,
+      },
+      {
+        id: '7daa881b-4209-44a1-8f37-2388385783b0',
+        name: 'suf3',
+        description: 'test deprecated',
+        deprecated: false,
+      },
+    ];
+    const intl = useIntl();
+    const actual = getSuffixOptions(records, intl);
+    const expected = [
+      {
+        label: 'suf',
+        value: 'suf',
+      },
+      {
+        label: 'suf2 (deprecated)',
+        value: 'suf2',
+      },
+      {
+        label: 'suf3',
+        value: 'suf3',
       },
     ];
 

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "okapiInterfaces": {
       "acquisition-methods": "1.0",
       "acquisitions-units": "1.1",
-      "configuration.prefixes": "1.1",
+      "configuration.prefixes": "1.2",
       "configuration.reasons-for-closure": "1.0",
-      "configuration.suffixes": "1.1",
+      "configuration.suffixes": "1.2",
       "contributor-name-types": "1.2",
       "finance.expense-classes": "2.0 3.0",
       "finance.funds": "1.4 2.0 3.0",

--- a/translations/ui-plugin-find-po-line/de.json
+++ b/translations/ui-plugin-find-po-line/de.json
@@ -6,7 +6,5 @@
     "modal.footer.close": "Schließen",
     "modal.footer.totalSelected": "Insgesamt ausgewählt: {count}",
     "filter.linkedPackagePOLine.accordion.label": "Verknüpfter Paketbestellposten",
-    "filter.linkedPackagePOLine.lookup.label": "Suche nach verknüpftem Paketbestellposten",
-    "filter.prefixFilter.deprecated": "veraltet",
-    "filter.suffixFilter.deprecated": "veraltet"
+    "filter.linkedPackagePOLine.lookup.label": "Suche nach verknüpftem Paketbestellposten"
 }

--- a/translations/ui-plugin-find-po-line/de.json
+++ b/translations/ui-plugin-find-po-line/de.json
@@ -6,5 +6,6 @@
     "modal.footer.close": "Schließen",
     "modal.footer.totalSelected": "Insgesamt ausgewählt: {count}",
     "filter.linkedPackagePOLine.accordion.label": "Verknüpfter Paketbestellposten",
-    "filter.linkedPackagePOLine.lookup.label": "Suche nach verknüpftem Paketbestellposten"
+    "filter.linkedPackagePOLine.lookup.label": "Suche nach verknüpftem Paketbestellposten",
+    "filter.prefixFilter.deprecated": "veraltet"
 }

--- a/translations/ui-plugin-find-po-line/de.json
+++ b/translations/ui-plugin-find-po-line/de.json
@@ -7,5 +7,6 @@
     "modal.footer.totalSelected": "Insgesamt ausgewählt: {count}",
     "filter.linkedPackagePOLine.accordion.label": "Verknüpfter Paketbestellposten",
     "filter.linkedPackagePOLine.lookup.label": "Suche nach verknüpftem Paketbestellposten",
-    "filter.prefixFilter.deprecated": "veraltet"
+    "filter.prefixFilter.deprecated": "veraltet",
+    "filter.suffixFilter.deprecated": "veraltet"
 }

--- a/translations/ui-plugin-find-po-line/en.json
+++ b/translations/ui-plugin-find-po-line/en.json
@@ -5,7 +5,9 @@
 
   "filter.linkedPackagePOLine.accordion.label": "Linked package POL",
   "filter.linkedPackagePOLine.lookup.label": "Linked package POL lookup",
-
+  
+  "filter.prefixFilter.deprecated": "deprecated",
+  
   "modal.title": "Select order lines",
 
   "modal.footer.save": "Save",

--- a/translations/ui-plugin-find-po-line/en.json
+++ b/translations/ui-plugin-find-po-line/en.json
@@ -6,7 +6,8 @@
   "filter.linkedPackagePOLine.accordion.label": "Linked package POL",
   "filter.linkedPackagePOLine.lookup.label": "Linked package POL lookup",
   
-  "filter.prefixSuffixFilter.deprecated": "{name} (deprecated)",
+  "filter.prefixFilter.deprecated": "{name} (deprecated)",
+  "filter.suffixFilter.deprecated": "{name} (deprecated)",
   
   "modal.title": "Select order lines",
 

--- a/translations/ui-plugin-find-po-line/en.json
+++ b/translations/ui-plugin-find-po-line/en.json
@@ -7,6 +7,7 @@
   "filter.linkedPackagePOLine.lookup.label": "Linked package POL lookup",
   
   "filter.prefixFilter.deprecated": "deprecated",
+  "filter.suffixFilter.deprecated": "deprecated",
   
   "modal.title": "Select order lines",
 

--- a/translations/ui-plugin-find-po-line/en.json
+++ b/translations/ui-plugin-find-po-line/en.json
@@ -6,8 +6,7 @@
   "filter.linkedPackagePOLine.accordion.label": "Linked package POL",
   "filter.linkedPackagePOLine.lookup.label": "Linked package POL lookup",
   
-  "filter.prefixFilter.deprecated": "deprecated",
-  "filter.suffixFilter.deprecated": "deprecated",
+  "filter.prefixSuffixFilter.deprecated": "{name} (deprecated)",
   
   "modal.title": "Select order lines",
 


### PR DESCRIPTION

[suffix_prefix_filter.webm](https://github.com/user-attachments/assets/63f1bb25-199e-481e-a6c9-befcf08c401a)
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

https://folio-org.atlassian.net/browse/UIOR-1450

Add hints for deprecated suffixes and prefixes in filters for search.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

The needed interface version got increased to

"configuration.prefixes": "1.2"
"configuration.suffixes": "1.2"

With these versions, the prefix and suffix objects get the flag deprecated, to signal that the prefix/suffix should not be used anymore.

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
