### PR TITLE
[UIPFPOL-90] Add hint if a prefix, suffix is deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## (6.1.0 IN PROGRESS)
 
+* Add hints for deprecated suffixes and prefixes in filters for search. Refs UIPFPOL-90.
+
 ## [6.0.1](https://github.com/folio-org/ui-plugin-find-po-line/tree/v6.0.1) (2025-04-04)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-po-line/compare/v6.0.0...v6.0.1)
 

--- a/FindPOLine/PrefixFilter/PrefixFilter.js
+++ b/FindPOLine/PrefixFilter/PrefixFilter.js
@@ -1,14 +1,16 @@
 import PropTypes from 'prop-types';
 import { useMemo } from 'react';
+import { useIntl } from 'react-intl';
 
 import { SelectionFilter } from '@folio/stripes-acq-components';
 
 import { usePrefixes } from '../hooks';
+import { getPrefixOptions } from '../utils';
 
 function PrefixFilter({ tenantId, ...rest }) {
   const { prefixes } = usePrefixes({ tenantId });
-
-  const options = useMemo(() => prefixes.map(({ name }) => ({ label: name, value: name })), [prefixes]);
+  const intl = useIntl();
+  const options = useMemo(() => getPrefixOptions(prefixes, intl), [prefixes, intl]);
 
   return (
     <SelectionFilter

--- a/FindPOLine/SuffixFilter/SuffixFilter.js
+++ b/FindPOLine/SuffixFilter/SuffixFilter.js
@@ -1,14 +1,16 @@
 import PropTypes from 'prop-types';
 import { useMemo } from 'react';
+import { useIntl } from 'react-intl';
 
 import { SelectionFilter } from '@folio/stripes-acq-components';
 
 import { useSuffixes } from '../hooks';
+import { getSuffixOptions } from '../utils';
 
 const SuffixFilter = ({ tenantId, ...rest }) => {
   const { suffixes } = useSuffixes({ tenantId });
-
-  const options = useMemo(() => suffixes.map(({ name }) => ({ label: name, value: name })), [suffixes]);
+  const intl = useIntl();
+  const options = useMemo(() => getSuffixOptions(suffixes, intl), [suffixes, intl]);
 
   return (
     <SelectionFilter

--- a/FindPOLine/utils.js
+++ b/FindPOLine/utils.js
@@ -128,3 +128,57 @@ export function getLinesQuery(queryParams, ky, localeDateFormat, customFields) {
     return buildOrderLinesQuery(queryParams, isbnData?.isbn, isbnData?.isbnType, localeDateFormat, customFields);
   };
 }
+
+/**
+ * Generate options with deprecated labels for a dropdown.
+ * @param {object[]} records - array of json objects with { name, deprecated }
+ * @param {class} intl - class for internationalization
+ * @param {string} deprecatedMessageId - intl message ID for labels
+ * @returns {object[]} array of {label, value} pairs.
+ */
+const generateOptionsWithDeprecationLabels = (
+  records,
+  intl,
+  deprecatedMessageId,
+) => records
+  .map(({ name, deprecated }) => {
+    return {
+      label: deprecated
+        ? intl.formatMessage({ id: deprecatedMessageId }, { name })
+        : name,
+      value: name,
+    };
+  });
+
+/**
+ * Calculate the options of a prefix to use in a dropdown.
+ * https://github.com/folio-org/acq-models/blob/master/mod-orders-storage/schemas/prefix.json
+ * @param {object[]} records - array of json objects (prefix) with { name, deprecated }
+ * @param {string} initialSelectedValue - the value of the dropdown on initialization
+ * @param {class} intl - class for internationalization
+ * @returns {object[]} array of {label, value} pairs.
+ */
+export const getPrefixOptions = (
+  records,
+  intl,
+) => generateOptionsWithDeprecationLabels(
+  records,
+  intl,
+  'ui-plugin-find-po-line.filter.prefixFilter.deprecated',
+);
+
+/**
+ * Calculate the options of a suffix to use in a dropdown.
+ * https://github.com/folio-org/acq-models/blob/master/mod-orders-storage/schemas/suffix.json
+ * @param {object[]} records - array of json objects (suffix) with { name, deprecated }
+ * @param {class} intl - class for internationalization
+ * @returns {object[]} array of {label, value} pairs.
+ */
+export const getSuffixOptions = (
+  records,
+  intl,
+) => generateOptionsWithDeprecationLabels(
+  records,
+  intl,
+  'ui-plugin-find-po-line.filter.suffixFilter.deprecated',
+);

--- a/FindPOLine/utils.test.js
+++ b/FindPOLine/utils.test.js
@@ -1,3 +1,4 @@
+import { useIntl } from 'react-intl';
 import {
   CUSTOM_FIELDS_FILTER,
   CUSTOM_FIELDS_FIXTURE,
@@ -9,7 +10,14 @@ import { FILTERS } from './constants';
 import {
   buildOrderLinesQuery,
   getDateRangeValueAsString,
+  getPrefixOptions,
+  getSuffixOptions,
 } from './utils';
+
+jest.mock('react-intl', () => ({
+  ...jest.requireActual('react-intl'),
+  useIntl: jest.fn(),
+}));
 
 describe('Utils', () => {
   describe('getDateRangeValueAsString', () => {
@@ -73,5 +81,111 @@ describe('Utils', () => {
 
       expect(parts.every(s => query.includes(s))).toBe(true);
     });
+  });
+});
+
+describe('getPrefixOptions', () => {
+  beforeEach(() => {
+    useIntl.mockReturnValue({
+      formatMessage: (_, { name }) => `${name} (deprecated)`,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should show a hint for deprecated prefixes', () => {
+    const records = [
+      {
+        id: 'db9f5d17-0ca3-4d14-ae49-16b63c8fc083',
+        name: 'pref',
+        description: 'Prefix for test purposes',
+        deprecated: false,
+      },
+      {
+        id: 'a91e8e98-2e83-4e05-abc7-908ba801edb0',
+        name: 'pref2',
+        description: 'test deprecated',
+        deprecated: true,
+      },
+      {
+        id: '7daa881b-4209-44a1-8f37-2388385783b0',
+        name: 'pref3',
+        description: 'test deprecated',
+        deprecated: false,
+      },
+    ];
+    const intl = useIntl();
+    const actual = getPrefixOptions(records, intl);
+    const expected = [
+      {
+        label: 'pref',
+        value: 'pref',
+      },
+      {
+        label: 'pref2 (deprecated)',
+        value: 'pref2',
+      },
+      {
+        label: 'pref3',
+        value: 'pref3',
+      },
+    ];
+
+    expect(actual).toEqual(expected);
+  });
+});
+
+describe('getSuffixOptions', () => {
+  beforeEach(() => {
+    useIntl.mockReturnValue({
+      formatMessage: (_, { name }) => `${name} (deprecated)`,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should show a hint for deprecated suffixes', () => {
+    const records = [
+      {
+        id: 'db9f5d17-0ca3-4d14-ae49-16b63c8fc083',
+        name: 'suf',
+        description: 'Suffix for test purposes',
+        deprecated: false,
+      },
+      {
+        id: 'a91e8e98-2e83-4e05-abc7-908ba801edb0',
+        name: 'suf2',
+        description: 'test deprecated',
+        deprecated: true,
+      },
+      {
+        id: '7daa881b-4209-44a1-8f37-2388385783b0',
+        name: 'suf3',
+        description: 'test deprecated',
+        deprecated: false,
+      },
+    ];
+    const intl = useIntl();
+    const actual = getSuffixOptions(records, intl);
+    const expected = [
+      {
+        label: 'suf',
+        value: 'suf',
+      },
+      {
+        label: 'suf2 (deprecated)',
+        value: 'suf2',
+      },
+      {
+        label: 'suf3',
+        value: 'suf3',
+      },
+    ];
+
+    expect(actual).toEqual(expected);
   });
 });

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "okapiInterfaces": {
       "acquisition-methods": "1.0",
       "acquisitions-units": "1.1",
-      "configuration.prefixes": "1.1",
+      "configuration.prefixes": "1.2",
       "configuration.reasons-for-closure": "1.0",
-      "configuration.suffixes": "1.1",
+      "configuration.suffixes": "1.2",
       "contributor-name-types": "1.2",
       "finance.expense-classes": "2.0 3.0",
       "finance.funds": "1.4 2.0 3.0",

--- a/translations/ui-plugin-find-po-line/en.json
+++ b/translations/ui-plugin-find-po-line/en.json
@@ -5,7 +5,10 @@
 
   "filter.linkedPackagePOLine.accordion.label": "Linked package POL",
   "filter.linkedPackagePOLine.lookup.label": "Linked package POL lookup",
-
+  
+  "filter.prefixFilter.deprecated": "{name} (deprecated)",
+  "filter.suffixFilter.deprecated": "{name} (deprecated)",
+  
   "modal.title": "Select order lines",
 
   "modal.footer.save": "Save",


### PR DESCRIPTION
[suffix_prefix_filter.webm](https://github.com/user-attachments/assets/63f1bb25-199e-481e-a6c9-befcf08c401a)
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

https://folio-org.atlassian.net/browse/UIPFPOL-90

Add hints for deprecated suffixes and prefixes in filters for search.

It is a continuation of this closed PR:

https://github.com/folio-org/ui-plugin-find-po-line/pull/188
