### PR TITLE
UIPFPOL-94 *BREAKING* Update CQL queries to use the new indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change history for ui-plugin-find-po-line
 
-## 6.2.0 (IN PROGRESS)
+## 7.0.0 (IN PROGRESS)
+
+* *BREAKING* Update CQL queries to use the new indices. Refs UIPFPOL-94.
 
 ## [6.1.1](https://github.com/folio-org/ui-plugin-find-po-line/tree/v6.1.1) (2026-05-22)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-po-line/compare/v6.1.0...v6.1.1)

--- a/FindPOLine/OrderLinesSearchConfig.js
+++ b/FindPOLine/OrderLinesSearchConfig.js
@@ -1,14 +1,14 @@
 import { dayjs } from '@folio/stripes/components';
 import {
+  CQLBuilder,
   CUSTOM_FIELDS_FILTER,
   CUSTOM_FIELDS_TYPES,
   DATE_FORMAT,
-  generateQueryTemplate,
   getCustomFieldsKeywordIndexes,
 } from '@folio/stripes-acq-components';
 
 export const QUERY_INDEX = {
-  CONTRIBUTORS: 'contributors',
+  CONTRIBUTORS: 'contributorName',
   PO_LINE_NUMBER: 'poLineNumber',
   REQUESTER: 'requester',
   TITLE_OR_PACKAGE: 'titleOrPackage',
@@ -17,11 +17,17 @@ export const QUERY_INDEX = {
   REFERENCE_NUMBERS: 'vendorDetail.referenceNumbers',
   DONOR: 'donor',
   SELECTOR: 'selector',
-  VOLUMES: 'physical.volumes',
-  PRODUCT_IDS: 'details.productIds',
+  VOLUMES: 'physicalVolumes',
+  PRODUCT_IDS: 'productIds',
 };
 
 const indexes = Object.values(QUERY_INDEX);
+
+const searchIndexTranslationKeyDict = {
+  [QUERY_INDEX.CONTRIBUTORS]: 'contributors',
+  [QUERY_INDEX.PRODUCT_IDS]: 'details.productIds',
+  [QUERY_INDEX.VOLUMES]: 'physical.volumes',
+};
 
 export const indexISBN = {
   labelId: 'ui-orders.search.productIdISBN',
@@ -33,14 +39,34 @@ export const searchableIndexes = [
     labelId: 'ui-orders.search.keyword',
     value: '',
   },
-  ...indexes.map(index => ({ labelId: `ui-orders.search.${index}`, value: index })),
+  ...indexes.map(index => ({ labelId: `ui-orders.search.${searchIndexTranslationKeyDict[index] || index}`, value: index })),
   indexISBN,
 ];
 
-export const getCqlQuery = (query, sIndex, localeDateFormat, customFields) => {
-  const customField = customFields?.find(
-    (cf) => `${CUSTOM_FIELDS_FILTER}.${cf.refId}` === sIndex,
-  );
+const buildEqualQuery = (sIndex, sQuery) => new CQLBuilder().equal(sIndex, sQuery).build();
+
+// This formatters define how index, relation, modifiers and value should be formatted for specific search indexes.
+const cqlFormatters = [
+  {
+    selector: (qIndex, _customFields) => qIndex === QUERY_INDEX.PO_LINE_NUMBER,
+    formatter: buildEqualQuery,
+  },
+  {
+    selector: (qIndex, _customFields) => qIndex === QUERY_INDEX.VENDOR_ACCOUNT,
+    formatter: buildEqualQuery,
+  },
+  {
+    selector: (qIndex, customFields) => {
+      const customField = customFields?.find((cf) => `${CUSTOM_FIELDS_FILTER}.${cf.refId}` === qIndex);
+
+      return customField?.type === CUSTOM_FIELDS_TYPES.DATE_PICKER;
+    },
+    formatter: buildEqualQuery,
+  },
+];
+
+const getCqlQuery = (query, sIndex, localeDateFormat, customFields) => {
+  const customField = customFields?.find((cf) => `${CUSTOM_FIELDS_FILTER}.${cf.refId}` === sIndex);
 
   if (customField?.type === CUSTOM_FIELDS_TYPES.DATE_PICKER) {
     const isoDate = dayjs.utc(query, localeDateFormat).format(DATE_FORMAT);
@@ -48,30 +74,42 @@ export const getCqlQuery = (query, sIndex, localeDateFormat, customFields) => {
     return `${isoDate}*`;
   }
 
-  return `*${query}*`;
+  return query;
 };
 
-export const queryTemplate = generateQueryTemplate(indexes);
+/**
+ * Formats the search CQL query based on the provided index, locale date format, and custom fields.
+ * Define CQL formatting rules for specific search indexes in the `formatSearchCqlMap` object.
+ * Some indexes apply specific relations, such as equality or fuzzy matching.
+ *
+ * @param {string} query - The search query.
+ * @param {string} sIndex - The search index.
+ * @param {string} localeDateFormat - The locale date format.
+ * @param {Array} customFields - The custom fields.
+ * @returns {string} The formatted CQL query.
+ */
+export const formatSearchCql = (query, sIndex, localeDateFormat, customFields) => {
+  const cqlQueryValue = getCqlQuery(query, sIndex, localeDateFormat, customFields);
+  const formatCqlFn = cqlFormatters.find(({ selector }) => selector(sIndex, customFields))?.formatter;
 
-const defaultSearchIndexQueryBuilder = (query, sIndex, localeDateFormat, customFields) => {
-  const cqlQuery = getCqlQuery(query, sIndex, localeDateFormat, customFields);
-
-  return `${sIndex}=="${cqlQuery}"`;
+  return formatCqlFn
+    ? formatCqlFn(sIndex, cqlQueryValue)
+    : new CQLBuilder().fuzzy(sIndex, cqlQueryValue).build();
 };
 
 export const getKeywordQuery = (
   query,
   localeDateFormat,
   customFields,
-  sIndexQueryBuildersDict = {},
 ) => {
   const customFieldIndexes = getCustomFieldsKeywordIndexes(customFields);
 
-  return [...indexes, ...customFieldIndexes].reduce((acc, sIndex) => {
-    const searchValue = sIndexQueryBuildersDict[sIndex]
-      ? sIndexQueryBuildersDict[sIndex](query)
-      : defaultSearchIndexQueryBuilder(query, sIndex, localeDateFormat, customFields);
+  return [...indexes, ...customFieldIndexes].reduce(
+    (acc, sIndex) => {
+      const formattedQuery = formatSearchCql(query, sIndex, localeDateFormat, customFields);
 
-    return acc ? `${acc} or ${searchValue}` : searchValue;
-  }, '');
+      return acc ? `${acc} or ${formattedQuery}` : formattedQuery;
+    },
+    '',
+  );
 };

--- a/FindPOLine/OrderLinesSearchConfig.test.js
+++ b/FindPOLine/OrderLinesSearchConfig.test.js
@@ -1,8 +1,11 @@
+import { CQLBuilder } from '@folio/stripes-acq-components';
+
 import {
   getKeywordQuery,
   QUERY_INDEX,
 } from './OrderLinesSearchConfig';
 
+const { EQUAL, FUZZY } = CQLBuilder.OPERATORS;
 const QUERY = 'query';
 
 it('should return keyword query', () => {
@@ -13,5 +16,17 @@ it('should return keyword query', () => {
     { [QUERY_INDEX.PRODUCT_IDS]: (q) => `productIds = "${q}*"` },
   );
 
-  expect(keywordQuery).toBe(`contributors=="*${QUERY}*" or poLineNumber=="*${QUERY}*" or requester=="*${QUERY}*" or titleOrPackage=="*${QUERY}*" or publisher=="*${QUERY}*" or vendorDetail.vendorAccount=="*${QUERY}*" or vendorDetail.referenceNumbers=="*${QUERY}*" or donor=="*${QUERY}*" or selector=="*${QUERY}*" or physical.volumes=="*${QUERY}*" or productIds = "${QUERY}*"`);
+  expect(keywordQuery).toBe([
+    `contributorName${FUZZY}"${QUERY}"`,
+    `poLineNumber${EQUAL}"${QUERY}"`,
+    `requester${FUZZY}"${QUERY}"`,
+    `titleOrPackage${FUZZY}"${QUERY}"`,
+    `publisher${FUZZY}"${QUERY}"`,
+    `vendorDetail.vendorAccount${EQUAL}"${QUERY}"`,
+    `vendorDetail.referenceNumbers${FUZZY}"${QUERY}"`,
+    `donor${FUZZY}"${QUERY}"`,
+    `selector${FUZZY}"${QUERY}"`,
+    `physicalVolumes${FUZZY}"${QUERY}"`,
+    `productIds${FUZZY}"${QUERY}"`,
+  ].join(' or '));
 });

--- a/FindPOLine/utils.js
+++ b/FindPOLine/utils.js
@@ -44,7 +44,7 @@ export const getDateRangeValueAsString = (filterValue = '') => {
 const buildEqualCqlQuery = (sIndex, sQuery) => new CQLBuilder().equal(sIndex, sQuery).build();
 
 const buildMultiOptionCqlEqualQuery = (sIndex, sQuery) => {
-  return buildMultiOptionCqlQuery(sIndex, sQuery, { operator: CQLBuilder.OPERATORS.EQUALS });
+  return buildMultiOptionCqlQuery(sIndex, sQuery, { operator: CQLBuilder.OPERATORS.EQUAL });
 };
 
 const buildLocationsQuery = (filterValue) => {

--- a/FindPOLine/utils.js
+++ b/FindPOLine/utils.js
@@ -1,10 +1,11 @@
 import {
-  buildArrayFieldQuery,
   buildDateRangeQuery,
   buildDateTimeRangeQuery,
   buildFilterQuery,
+  buildMultiOptionCqlQuery,
   buildSortingQuery,
   connectQuery,
+  CQLBuilder,
   getCustomFieldsFilterMap,
   IDENTIFIER_TYPES_API,
   SEARCH_INDEX_PARAMETER,
@@ -16,37 +17,19 @@ import {
   QUALIFIER_SEPARATOR,
 } from './constants';
 import {
-  getCqlQuery,
+  formatSearchCql,
   getKeywordQuery,
-  QUERY_INDEX,
 } from './OrderLinesSearchConfig';
 
-const TRUNCATION_WILDCARD = '*';
-
-const buildProductIdsSearchQuery = (query) => {
-  const sanitizedQuery = query?.replaceAll(TRUNCATION_WILDCARD, '');
-
-  return `productIds = "${sanitizedQuery}*"`;
-};
-
 const defaultSearchFn = (localeDateFormat, customFields = []) => (query, qindex) => {
-  if (qindex === QUERY_INDEX.PRODUCT_IDS) {
-    return buildProductIdsSearchQuery(query);
-  }
-
   if (qindex) {
-    const cqlQuery = getCqlQuery(query, qindex, localeDateFormat, customFields);
-
-    return `(${qindex}=="${cqlQuery}")`;
+    return formatSearchCql(query, qindex, localeDateFormat, customFields);
   }
 
   return getKeywordQuery(
     query,
     localeDateFormat,
     customFields,
-    {
-      [QUERY_INDEX.PRODUCT_IDS]: buildProductIdsSearchQuery,
-    },
   );
 };
 
@@ -56,6 +39,19 @@ export const getDateRangeValueAsString = (filterValue = '') => {
   }
 
   return filterValue;
+};
+
+const buildEqualCqlQuery = (sIndex, sQuery) => new CQLBuilder().equal(sIndex, sQuery).build();
+
+const buildMultiOptionCqlEqualQuery = (sIndex, sQuery) => {
+  return buildMultiOptionCqlQuery(sIndex, sQuery, { operator: CQLBuilder.OPERATORS.EQUALS });
+};
+
+const buildLocationsQuery = (filterValue) => {
+  return [
+    buildMultiOptionCqlQuery(FILTERS.LOCATION, filterValue, { modifiers: [{ name: '@locationId' }] }),
+    buildMultiOptionCqlQuery('searchLocations', filterValue),
+  ].join(` ${CQLBuilder.OPERATORS.OR} `);
 };
 
 export const buildOrderLinesQuery = (
@@ -84,21 +80,17 @@ export const buildOrderLinesQuery = (
       [FILTERS.EXPECTED_RECEIPT_DATE]: buildDateRangeQuery.bind(null, `physical.${FILTERS.EXPECTED_RECEIPT_DATE}`),
       [FILTERS.RECEIPT_DUE]: buildDateRangeQuery.bind(null, `physical.${FILTERS.RECEIPT_DUE}`),
       [FILTERS.CLAIM_SENT]: buildDateRangeQuery.bind(null, [FILTERS.CLAIM_SENT]),
-      [FILTERS.TAGS]: buildArrayFieldQuery.bind(null, [FILTERS.TAGS]),
-      [FILTERS.FUND_CODE]: (filterValue) => `fundDistribution =/@fundId (${Array.isArray(filterValue) ? filterValue.join(' or ') : filterValue})`,
-      [FILTERS.EXPENSE_CLASS]: buildArrayFieldQuery.bind(null, [FILTERS.FUND_DISTRIBUTION]),
-      [FILTERS.LOCATION]: (filterValue) => `(${
-        [FILTERS.LOCATION, 'searchLocationIds']
-          .map((filterKey) => buildArrayFieldQuery(filterKey, filterValue))
-          .join(' or ')
-      })`,
-      [FILTERS.DONOR]: buildArrayFieldQuery.bind(null, [FILTERS.DONOR]),
-      [FILTERS.ACQUISITIONS_UNIT]: buildArrayFieldQuery.bind(null, [FILTERS.ACQUISITIONS_UNIT]),
-      [FILTERS.MATERIAL_TYPE_PHYSICAL]: (filterValue) => `physical.materialType == ${filterValue}`,
-      [FILTERS.MATERIAL_TYPE_ELECTRONIC]: (filterValue) => `eresource.materialType == ${filterValue}`,
-      [FILTERS.ACCESS_PROVIDER]: (filterValue) => `eresource.${FILTERS.ACCESS_PROVIDER} == ${filterValue}`,
-      [FILTERS.ACTIVATED]: (filterValue) => `eresource.${FILTERS.ACTIVATED} == ${filterValue}`,
-      [FILTERS.TRIAL]: (filterValue) => `eresource.${FILTERS.TRIAL} == ${filterValue}`,
+      [FILTERS.TAGS]: buildMultiOptionCqlQuery.bind(null, FILTERS.TAGS),
+      [FILTERS.FUND_CODE]: (filterValue) => buildMultiOptionCqlQuery(FILTERS.FUND_DISTRIBUTION, filterValue, { modifiers: [{ name: '@fundId' }] }),
+      [FILTERS.EXPENSE_CLASS]: buildMultiOptionCqlQuery.bind(null, FILTERS.FUND_DISTRIBUTION),
+      [FILTERS.LOCATION]: (filterValue) => buildLocationsQuery(filterValue),
+      [FILTERS.DONOR]: buildMultiOptionCqlQuery.bind(null, [FILTERS.DONOR]),
+      [FILTERS.ACQUISITIONS_UNIT]: buildMultiOptionCqlQuery.bind(null, FILTERS.ACQUISITIONS_UNIT),
+      [FILTERS.MATERIAL_TYPE_PHYSICAL]: buildEqualCqlQuery.bind(null, 'physical.materialType'),
+      [FILTERS.MATERIAL_TYPE_ELECTRONIC]: buildEqualCqlQuery.bind(null, 'eresource.materialType'),
+      [FILTERS.ACCESS_PROVIDER]: buildEqualCqlQuery.bind(null, `eresource.${FILTERS.ACCESS_PROVIDER}`),
+      [FILTERS.ACTIVATED]: buildMultiOptionCqlEqualQuery.bind(null, `eresource.${FILTERS.ACTIVATED}`),
+      [FILTERS.TRIAL]: buildMultiOptionCqlEqualQuery.bind(null, `eresource.${FILTERS.TRIAL}`),
       ...getCustomFieldsFilterMap(customFields),
     },
     true,

--- a/FindPOLine/utils.test.js
+++ b/FindPOLine/utils.test.js
@@ -1,5 +1,6 @@
 import { useIntl } from 'react-intl';
 import {
+  CQLBuilder,
   CUSTOM_FIELDS_FILTER,
   CUSTOM_FIELDS_FIXTURE,
   SEARCH_INDEX_PARAMETER,
@@ -19,6 +20,9 @@ jest.mock('react-intl', () => ({
   useIntl: jest.fn(),
 }));
 
+const { EQUAL, FUZZY, OR } = CQLBuilder.OPERATORS;
+const QUERY_PARTS_SEPARATOR = ` ${OR} `;
+
 describe('Utils', () => {
   describe('getDateRangeValueAsString', () => {
     it('should return string value', () => {
@@ -31,7 +35,10 @@ describe('Utils', () => {
     it('should return search query based on location filter', () => {
       const query = buildOrderLinesQuery({ [FILTERS.LOCATION]: 'locationId' });
 
-      expect(query).toContain('(locations=="*locationId*" or searchLocationIds=="*locationId*")');
+      expect(query).toContain(`(${[
+        'locations =/@locationId "locationId"',
+        'searchLocations="locationId"',
+      ].join(QUERY_PARTS_SEPARATOR)})`);
     });
 
     it('should return filter query based on datepicker custom field', () => {
@@ -62,7 +69,7 @@ describe('Utils', () => {
         CUSTOM_FIELDS_FIXTURE,
       );
 
-      expect(query).toContain('(customFields.datepicker=="2021-01-30*")');
+      expect(query).toContain(`(${CUSTOM_FIELDS_FILTER}.datepicker${EQUAL}"2021-01-30*")`);
     });
 
     it('should return keyword query with custom fields indexes', () => {
@@ -74,9 +81,9 @@ describe('Utils', () => {
         CUSTOM_FIELDS_FIXTURE,
       );
       const parts = [
-        'datepicker=="Invalid Date*"',
-        'shorttext=="*abc*"',
-        'longtext=="*abc*"',
+        `datepicker${EQUAL}"Invalid Date*"`,
+        `shorttext${FUZZY}"abc"`,
+        `longtext${FUZZY}"abc"`,
       ].map((s) => `${CUSTOM_FIELDS_FILTER}.${s}`);
 
       expect(parts.every(s => query.includes(s))).toBe(true);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/plugin-find-po-line",
-  "version": "6.1.1",
+  "version": "7.0.0",
   "description": "Find and select PO lines plugin for Stripes",
   "repository": "folio-org/ui-plugin-find-po-line",
   "publishConfig": {
@@ -78,7 +78,7 @@
     "regenerator-runtime": "^0.13.3"
   },
   "dependencies": {
-    "@folio/stripes-acq-components": "~7.1.0",
+    "@folio/stripes-acq-components": "~7.2.0",
     "lodash": "^4.17.11",
     "prop-types": "^15.6.0"
   },


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UIPFPOL-94

Requires https://github.com/folio-org/stripes-acq-components/pull/951

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

- Use `buildMultiOptionCqlQuery` to update CQL with relation modifiers;
- Update relations for search indices;
- Remove wrapping the filter value in wildcards;
- Update tests.