### PR TITLE
UIPFPOL-95 Show deprecated acquisition methods in the order-lines filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 7.0.0 (IN PROGRESS)
 
 * *BREAKING* Update CQL queries to use the new indices. Refs UIPFPOL-94.
+* Show deprecated acquisition methods in the order-lines filter. Refs UIPFPOL-95.
 
 ## [6.1.1](https://github.com/folio-org/ui-plugin-find-po-line/tree/v6.1.1) (2026-05-22)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-po-line/compare/v6.1.0...v6.1.1)

--- a/FindPOLine/AcqMethodsFilter/AcqMethodsFilter.js
+++ b/FindPOLine/AcqMethodsFilter/AcqMethodsFilter.js
@@ -18,7 +18,7 @@ const AcqMethodsFilter = ({
   tenantId,
 }) => {
   const { acquisitionMethods } = useAcquisitionMethods({ tenantId });
-  const options = useAcqMethodsOptions(acquisitionMethods);
+  const options = useAcqMethodsOptions(acquisitionMethods, { withDeprecatedSuffix: true });
 
   return (
     <FilterAccordion

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
       "@folio/stripes-acq-components"
     ],
     "okapiInterfaces": {
-      "acquisition-methods": "1.0",
+      "acquisition-methods": "1.1",
       "acquisitions-units": "1.1",
       "configuration.prefixes": "1.2",
       "configuration.reasons-for-closure": "1.0",


### PR DESCRIPTION
[UIPFPOL-95](https://folio-org.atlassian.net/browse/UIPFPOL-95)

## Purpose
Deprecated acquisition methods must stay searchable but should be marked as such, so the order-lines Acquisition method filter keeps them selectable and suffixes them `(deprecated)`. 

## Approach
- The Acquisition method filter passes `{ withDeprecatedSuffix: true }` to `useAcqMethodsOptions`
- Interface dependency is bumped

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
    - Interface for backend is bumped and stripes-acq-components PR merged already.
  - [x] There are no breaking changes in this PR.